### PR TITLE
Find action bound to weather instead of using service name.

### DIFF
--- a/main.js
+++ b/main.js
@@ -175,7 +175,7 @@ function getWeatherCompanyForecast(geocode) {
         const result = results[i];
         console.log(result);
         console.log(result.name);
-        if (result.name.startsWith('Bluemix_Weather Company Data')) {
+        if (result.binding.name === 'weather') {
           name = '/' + result.namespace + '/' + result.name + '/forecast';
           break;
         }

--- a/test/unit/test.main.js
+++ b/test/unit/test.main.js
@@ -49,9 +49,16 @@ describe('test actionHandler()', function() {
         )
       },
       packages: {
-        list: sinon
-          .stub()
-          .returns(Promise.resolve([{ name: 'test-other' }, { name: 'Bluemix_Weather Company Data-credentials123', namespace: 'test-namespace' }]))
+        list: sinon.stub().returns(
+          Promise.resolve([
+            { name: 'test-other', binding: {} },
+            {
+              name: 'Whatevr_Weather Company Data-credentials123',
+              namespace: 'test-namespace',
+              binding: { name: 'weather' }
+            }
+          ])
+        )
       }
     };
   };


### PR DESCRIPTION
The search based on name did not work if the service name
was not like the default.  Using the one bound to "weather"
will, hopefully, be more robust.

Closes #16