### PR TITLE
Make Redis optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ To find the `WORKSPACE_ID` for Watson Assistant:
 
 ### 3. Create a Databases for Redis service
 
+> NOTE: Redis is now optional. We've kept the Redis code to show how to use it, but we are also saving the context in session attributes. If you remove the REDIS_URI parameter, it will still work.
+
 Create the service by following this link and hitting `Create`:
 
 * [**Databases for Redis**](https://cloud.ibm.com/catalog/services/databases-for-redis)

--- a/main.js
+++ b/main.js
@@ -103,8 +103,8 @@ function getSessionContext(sessionId) {
 
   return new Promise(function(resolve, reject) {
     if (redisClient === null) {
-        // Redis is optional now. Will get context from session attributes.
-        resolve();
+      // Redis is optional now. Will get context from session attributes.
+      resolve();
     } else {
       // Keeping Redis as an example of Redis integration.
       redisClient.get(sessionId, function(err, value) {
@@ -304,10 +304,10 @@ function main(args) {
     const alexaAttributes = body.session.attributes;
     console.log('Alexa attributes:');
     console.log(alexaAttributes);
-    if (typeof alexaAttributes !== "undefined" && alexaAttributes.hasOwnProperty('watsonContext')) {
+    if (typeof alexaAttributes !== 'undefined' && Object.prototype.hasOwnProperty.call(alexaAttributes, 'watsonContext')) {
       context = alexaAttributes.watsonContext;
     } else {
-      context = {}
+      context = {};
     }
 
     const request = body.request;

--- a/main.js
+++ b/main.js
@@ -93,8 +93,8 @@ function initClients(args) {
 
     console.log('Connected to Redis');
   } else {
-    console.error('Missing REDIS_URI');
-    throw Error('Missing required configuration of REDIS_URI');
+    redisClient = null;
+    console.log('Missing REDIS_URI Will use session attributes instead of Redis.');
   }
 }
 
@@ -102,17 +102,23 @@ function getSessionContext(sessionId) {
   console.log('Alexa sessionId: ' + sessionId);
 
   return new Promise(function(resolve, reject) {
-    redisClient.get(sessionId, function(err, value) {
-      if (err) {
-        console.error(err);
-        reject(Error('Error getting context from Redis.'));
-      }
-      // set global context
-      context = value ? JSON.parse(value) : {};
-      console.log('Watson context from Redis:');
-      console.log(context);
-      resolve();
-    });
+    if (redisClient === null) {
+        // Redis is optional now. Will get context from session attributes.
+        resolve();
+    } else {
+      // Keeping Redis as an example of Redis integration.
+      redisClient.get(sessionId, function(err, value) {
+        if (err) {
+          console.error(err);
+          reject(Error('Error getting context from Redis.'));
+        }
+        // set global context
+        context = value ? JSON.parse(value) : {};
+        console.log('Watson context from Redis:');
+        console.log(context);
+        resolve();
+      });
+    }
   });
 }
 
@@ -267,14 +273,18 @@ function saveSessionContext(sessionId) {
   console.log('Begin saveSessionContext');
   console.log(sessionId);
 
-  // Save the context in Redis. Can do this after resolve(response).
-  if (context) {
-    const newContextString = JSON.stringify(context);
-    // Saved context will expire in 600 secs.
-    redisClient.set(sessionId, newContextString, 'EX', 600);
-    console.log('Saved context in Redis');
-    console.log(sessionId);
-    console.log(newContextString);
+  if (redisClient === null) {
+    console.log('Skipped saving context in Redis.');
+  } else {
+    // Save the context in Redis. Can do this after resolve(response).
+    if (context) {
+      const newContextString = JSON.stringify(context);
+      // Saved context will expire in 600 secs.
+      redisClient.set(sessionId, newContextString, 'EX', 600);
+      console.log('Saved context in Redis');
+      console.log(sessionId);
+      console.log(newContextString);
+    }
   }
 }
 
@@ -290,10 +300,15 @@ function main(args) {
     const body = JSON.parse(rawBody);
     const sessionId = body.session.sessionId;
 
-    // Alexa attributes hold our context (for future use)
+    // Alexa attributes hold our context (making Redis optional)
     const alexaAttributes = body.session.attributes;
     console.log('Alexa attributes:');
     console.log(alexaAttributes);
+    if (typeof alexaAttributes !== "undefined" && alexaAttributes.hasOwnProperty('watsonContext')) {
+      context = alexaAttributes.watsonContext;
+    } else {
+      context = {}
+    }
 
     const request = body.request;
 


### PR DESCRIPTION
2 reasons for this:

1) There is no free tier. So it is a barrier for devs to use it.
2) I figured out how to stash the context in Alexa session attributes. So there really isn't any need for the DB.

But... I'm keeping the Redis code so we still have this example for how to use Redis.